### PR TITLE
ClickHouse metric updates

### DIFF
--- a/clickhouse/db-system-events.yml
+++ b/clickhouse/db-system-events.yml
@@ -30,10 +30,6 @@ observation:
         type: counter
         label: Insert query count
         description: Number of INSERT queries started to be interpreted and may be executed.
-      - name: file.open.failed
-        source: FileOpenFailed
-        type: counter
-        label: Failed file opens
       - name: buffer.read.fd.failed
         source: ReadBufferFromFileDescriptorReadFailed
         type: counter

--- a/clickhouse/db-system-events.yml
+++ b/clickhouse/db-system-events.yml
@@ -30,6 +30,10 @@ observation:
         type: counter
         label: Insert query count
         description: Number of INSERT queries started to be interpreted and may be executed.
+      - name: file.open.failed	
+        source: FileOpenFailed	
+        type: counter	
+        label: Failed file opens
       - name: buffer.read.fd.failed
         source: ReadBufferFromFileDescriptorReadFailed
         type: counter

--- a/clickhouse/db-system-replicas.yml
+++ b/clickhouse/db-system-replicas.yml
@@ -8,7 +8,11 @@ data:
       parts_to_check,
       queue_size,
       inserts_in_queue,
-      merges_in_queue
+      merges_in_queue,
+      log_max_index,
+      log_pointer,
+      total_replicas,
+      active_replicas
     FROM system.replicas;
   dbUrl: jdbc:clickhouse://${SPM_MONITOR_CLICKHOUSE_DB_HOST_PORT}/system
   dbDriverClass: ru.yandex.clickhouse.ClickHouseDriver
@@ -63,6 +67,26 @@ observation:
         type: long_gauge
         label: Replica queue merges
         description: The number of merges waiting to be made. Sometimes merges are lengthy, so this value may be greater than zero for a long time
+      - name: replica.log.max.index
+        source: log_max_index
+        type: long_gauge
+        label: Replica log max index
+        description: Maximum entry number in the log of general activity.
+      - name: replica.log.pointer
+        source: log_pointer
+        type: long_gauge
+        label: Replica log pointer
+        description: Maximum entry number in the log of general activity that the replica copied to its execution queue, plus one. If log pointer is much smaller than log max index, something is wrong.
+      - name: replica.total.replicas
+        source: total_replicas
+        type: long_gauge
+        label: Total replicas
+        description: The total number of known replicas of this table.
+      - name: replica.active.replicas
+        source: active_replicas
+        type: long_gauge
+        label: Active replicas
+        description: The number of replicas of this table that have a session in ZooKeeper (i.e., the number of functioning replicas).
 
     tag:
       - name: clickhouse.database


### PR DESCRIPTION
- Removed `FileOpenFailed` metric since this has been removed in current CH version
- Added replica metrics that are fetched internally from ZK. This added some delay to fetching replica metrics. Tested this adds ~14ms delay to fetch replica metrics in our prod (we have 3 tables. delay increases linearly with table count). If users see more delay in their setup they can remove these metrics. Report changes will be done as part of SC-3171

Verified with a standalone remote CH monitor in prod.