### PR TITLE
Fix typo in lock naming

### DIFF
--- a/postgresql/db-lock-status.yml
+++ b/postgresql/db-lock-status.yml
@@ -31,7 +31,7 @@ observation:
         description: Name of the lock mode held or desired
 
       - name: lock.relation
-        source: relation
+        source: relname
         type: text
         send: false
         label: lock name


### PR DESCRIPTION
The `source` for the tag wasn't correct, preventing the agent from sending the `lock.count` metric.