### PR TITLE
added Solr merge metrics

### DIFF
--- a/solr/jmx-merge-solr7plus.yml
+++ b/solr/jmx-merge-solr7plus.yml
@@ -1,0 +1,342 @@
+type: jmx
+require:
+  - className: com.sematext.spm.client.solr.SolrVersionCheck
+    values: 7-*
+
+observation:
+  - name: merge_errors_solr7_cloud
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=errors
+
+    metric:
+      - name: index.merge.errors
+        source: Count
+        type: counter
+        label: merge errors
+        description: merge errors
+
+    tag:
+      - name: solr.collection
+        value: ${collection}
+
+      - name: solr.shard
+        value: ${shard}
+
+      - name: solr.replica
+        value: ${replica}
+
+      - name: solr.core
+        value: func:ConcatUsingString(_,collection,shard,replica)
+
+  - name: merge_minor_solr7_cloud
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=minor
+
+    metric:
+      - name: index.merge.minor
+        source: Count
+        type: counter
+        label: minor merges
+        description: minor merges
+
+    tag:
+      - name: solr.collection
+        value: ${collection}
+
+      - name: solr.shard
+        value: ${shard}
+
+      - name: solr.replica
+        value: ${replica}
+
+      - name: solr.core
+        value: func:ConcatUsingString(_,collection,shard,replica)
+
+  - name: merge_minor_running_docs_solr7_cloud
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=minor.running.docs
+
+    metric:
+      - name: index.merge.minor.running.docs
+        source: Value
+        type: counter
+        label: docs merged in minor merges
+        description: docs merged in minor merges
+
+    tag:
+      - name: solr.collection
+        value: ${collection}
+
+      - name: solr.shard
+        value: ${shard}
+
+      - name: solr.replica
+        value: ${replica}
+
+      - name: solr.core
+        value: func:ConcatUsingString(_,collection,shard,replica)
+
+  - name: merge_minor_running_segments_solr7_cloud
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=minor.running.segments
+
+    metric:
+      - name: index.merge.minor.running.segments
+        source: Value
+        type: counter
+        label: segments merged in minor merges
+        description: segments merged in minor merges
+
+    tag:
+      - name: solr.collection
+        value: ${collection}
+
+      - name: solr.shard
+        value: ${shard}
+
+      - name: solr.replica
+        value: ${replica}
+
+      - name: solr.core
+        value: func:ConcatUsingString(_,collection,shard,replica)
+
+  - name: merge_major_solr7_cloud
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=major
+
+    metric:
+      - name: index.merge.major
+        source: Count
+        type: counter
+        label: major merges
+        description: major merges
+
+    tag:
+      - name: solr.collection
+        value: ${collection}
+
+      - name: solr.shard
+        value: ${shard}
+
+      - name: solr.replica
+        value: ${replica}
+
+      - name: solr.core
+        value: func:ConcatUsingString(_,collection,shard,replica)
+
+  - name: merge_major_running_docs_solr7_cloud
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=major.running.docs
+
+    metric:
+      - name: index.merge.major.running.docs
+        source: Value
+        type: gauge
+        label: docs merged in major merges
+        description: docs merged in major merges
+
+    tag:
+      - name: solr.collection
+        value: ${collection}
+
+      - name: solr.shard
+        value: ${shard}
+
+      - name: solr.replica
+        value: ${replica}
+
+      - name: solr.core
+        value: func:ConcatUsingString(_,collection,shard,replica)
+
+  - name: merge_major_running_segments_solr7_cloud
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=major.running.segments
+
+    metric:
+      - name: index.merge.major.running.segments
+        source: Value
+        type: gauge
+        label: segments merged in major merges
+        description: segments merged in major merges
+
+    tag:
+      - name: solr.collection
+        value: ${collection}
+
+      - name: solr.shard
+        value: ${shard}
+
+      - name: solr.replica
+        value: ${replica}
+
+      - name: solr.core
+        value: func:ConcatUsingString(_,collection,shard,replica)
+
+  - name: merge_major_deleted_docs_solr7_cloud
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=major.deletedDocs
+
+    metric:
+      - name: index.merge.major.deletedDocs
+        source: Count
+        type: counter
+        label: expunged docs in major merges
+        description: deleted docs expunged in major merges
+
+    tag:
+      - name: solr.collection
+        value: ${collection}
+
+      - name: solr.shard
+        value: ${shard}
+
+      - name: solr.replica
+        value: ${replica}
+
+      - name: solr.core
+        value: func:ConcatUsingString(_,collection,shard,replica)
+
+#  "classic" Solr setup uses different bean names
+  - name: merge_errors_solr7_solr7_classic
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=errors
+
+    metric:
+      - name: index.merge.errors
+        source: Count
+        type: counter
+        label: merge errors
+        description: merge errors
+
+    tag:
+      - name: solr.core
+        value: ${core}
+
+      - name: solr.collection
+        value: ${core}
+
+  - name: merge_minor_solr7_classic
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=minor
+
+    metric:
+      - name: index.merge.minor
+        source: Count
+        type: counter
+        label: minor merges
+        description: minor merges
+
+    tag:
+      - name: solr.core
+        value: ${core}
+
+      - name: solr.collection
+        value: ${core}
+
+  - name: merge_minor_docs_solr7_classic
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=minor.running.docs
+
+    metric:
+      - name: index.merge.minor.running.docs
+        source: Value
+        type: counter
+        label: docs merged in minor merges
+        description: docs merged in minor merges
+
+    tag:
+      - name: solr.core
+        value: ${core}
+
+      - name: solr.collection
+        value: ${core}
+
+  - name: merge_minor_segments_solr7_classic
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=minor.running.segments
+
+    metric:
+      - name: index.merge.minor.running.segments
+        source: Value
+        type: counter
+        label: segments merged in minor merges
+        description: segments merged in minor merges
+
+    tag:
+      - name: solr.core
+        value: ${core}
+
+      - name: solr.collection
+        value: ${core}
+
+  - name: merge_major_solr7_classic
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=major
+
+    metric:
+      - name: index.merge.major
+        source: Count
+        type: counter
+        label: major merges
+        description: major merges
+
+    tag:
+      - name: solr.core
+        value: ${core}
+
+      - name: solr.collection
+        value: ${core}
+
+  - name: merge_major_docs_solr7_classic
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=major.running.docs
+
+    metric:
+      - name: index.merge.major.running.docs
+        source: Value
+        type: gauge
+        label: docs merged in major merges
+        description: docs merged in major merges
+
+    tag:
+      - name: solr.core
+        value: ${core}
+
+      - name: solr.collection
+        value: ${core}
+
+  - name: merge_major_segments_solr7_classic
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=major.running.segments
+
+    metric:
+      - name: index.merge.major.running.segments
+        source: Value
+        type: gauge
+        label: segments merged in major merges
+        description: segments merged in major merges
+
+    tag:
+      - name: solr.core
+        value: ${core}
+
+      - name: solr.collection
+        value: ${core}
+
+  - name: merge_major_deleted_docs_solr7_classic
+    metricNamespace: solr
+    objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=major.deletedDocs
+
+    metric:
+      - name: index.merge.major.deletedDocs
+        source: Count
+        type: counter
+        label: expunged docs in major merges
+        description: deleted docs expunged in major merges
+
+    tag:
+      - name: solr.core
+        value: ${core}
+
+      - name: solr.collection
+        value: ${core}

--- a/solr/jmx-merge-solr7plus.yml
+++ b/solr/jmx-merge-solr7plus.yml
@@ -9,7 +9,7 @@ observation:
     objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=errors
 
     metric:
-      - name: index.merge.errors
+      - name: index.merges.errors
         source: Count
         type: counter
         label: merge errors
@@ -33,7 +33,7 @@ observation:
     objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=minor
 
     metric:
-      - name: index.merge.minor
+      - name: index.merges.minor
         source: Count
         type: counter
         label: minor merges
@@ -57,11 +57,11 @@ observation:
     objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=minor.running.docs
 
     metric:
-      - name: index.merge.minor.running.docs
+      - name: index.merges.minor.running.docs
         source: Value
-        type: counter
-        label: docs merged in minor merges
-        description: docs merged in minor merges
+        type: gauge
+        label: docs in minor merges
+        description: docs in currently running minor merges
 
     tag:
       - name: solr.collection
@@ -81,11 +81,11 @@ observation:
     objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=minor.running.segments
 
     metric:
-      - name: index.merge.minor.running.segments
+      - name: index.merges.minor.running.segments
         source: Value
-        type: counter
-        label: segments merged in minor merges
-        description: segments merged in minor merges
+        type: gauge
+        label: segments in minor merges
+        description: segments in currently running minor merges
 
     tag:
       - name: solr.collection
@@ -105,7 +105,7 @@ observation:
     objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=major
 
     metric:
-      - name: index.merge.major
+      - name: index.merges.major
         source: Count
         type: counter
         label: major merges
@@ -129,11 +129,11 @@ observation:
     objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=major.running.docs
 
     metric:
-      - name: index.merge.major.running.docs
+      - name: index.merges.major.running.docs
         source: Value
         type: gauge
-        label: docs merged in major merges
-        description: docs merged in major merges
+        label: docs in major merges
+        description: docs in currently running major merges
 
     tag:
       - name: solr.collection
@@ -153,11 +153,11 @@ observation:
     objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=major.running.segments
 
     metric:
-      - name: index.merge.major.running.segments
+      - name: index.merges.major.running.segments
         source: Value
         type: gauge
-        label: segments merged in major merges
-        description: segments merged in major merges
+        label: segments in major merges
+        description: segments in currently running major merges
 
     tag:
       - name: solr.collection
@@ -177,7 +177,7 @@ observation:
     objectName: solr:dom1=core,dom2=${collection},dom3=${shard},dom4=${replica},category=INDEX,scope=merge,name=major.deletedDocs
 
     metric:
-      - name: index.merge.major.deletedDocs
+      - name: index.merges.major.deleted.docs
         source: Count
         type: counter
         label: expunged docs in major merges
@@ -202,7 +202,7 @@ observation:
     objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=errors
 
     metric:
-      - name: index.merge.errors
+      - name: index.merges.errors
         source: Count
         type: counter
         label: merge errors
@@ -220,7 +220,7 @@ observation:
     objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=minor
 
     metric:
-      - name: index.merge.minor
+      - name: index.merges.minor
         source: Count
         type: counter
         label: minor merges
@@ -238,7 +238,7 @@ observation:
     objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=minor.running.docs
 
     metric:
-      - name: index.merge.minor.running.docs
+      - name: index.merges.minor.running.docs
         source: Value
         type: counter
         label: docs merged in minor merges
@@ -256,7 +256,7 @@ observation:
     objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=minor.running.segments
 
     metric:
-      - name: index.merge.minor.running.segments
+      - name: index.merges.minor.running.segments
         source: Value
         type: counter
         label: segments merged in minor merges
@@ -274,7 +274,7 @@ observation:
     objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=major
 
     metric:
-      - name: index.merge.major
+      - name: index.merges.major
         source: Count
         type: counter
         label: major merges
@@ -292,7 +292,7 @@ observation:
     objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=major.running.docs
 
     metric:
-      - name: index.merge.major.running.docs
+      - name: index.merges.major.running.docs
         source: Value
         type: gauge
         label: docs merged in major merges
@@ -310,7 +310,7 @@ observation:
     objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=major.running.segments
 
     metric:
-      - name: index.merge.major.running.segments
+      - name: index.merges.major.running.segments
         source: Value
         type: gauge
         label: segments merged in major merges
@@ -328,7 +328,7 @@ observation:
     objectName: solr:dom1=core,dom2=${core},category=INDEX,scope=merge,name=major.deletedDocs
 
     metric:
-      - name: index.merge.major.deletedDocs
+      - name: index.merges.major.deleted.docs
         source: Count
         type: counter
         label: expunged docs in major merges


### PR DESCRIPTION
The caveat here is that "running" metrics have to be "caught". Meaning that if indexing activity is low, it's likely that you see docs/segments 0, even though there were some merges. I don't think there's much we can do about it, though.

Also, Solr doesn't expose these metrics by default. One needs to add the following to the `indexConfig` section in `solrconfig.xml`:

```
<metrics>
      <majorMergeDocs>500</majorMergeDocs> <!-- if a merge touched more than these docs, it's Major -->
      <bool name="mergeDetails">true</bool>
</metrics>
```