### PR TITLE
OpenSearch integration

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -1,0 +1,1 @@
+This directory contains the Sematext metrics definition YAMLs for OpenSearch.

--- a/opensearch/json-adaptive-selection.yml
+++ b/opensearch/json-adaptive-selection.yml
@@ -1,0 +1,68 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: adaptive_replica_selection
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.adaptive_selection.${remoteNodeId}
+
+    metric:
+      - name: adaptiveReplicaSelection.searches.outgoing
+        source: outgoing_searches
+        type: long_gauge
+        label: outgoing searches
+        description: searches from the monitored node to the remote node
+
+      - name: adaptiveReplicaSelection.queue.size.avg
+        source: avg_queue_size
+        type: double_gauge
+        label: average queue size
+        description: exponentially weighted moving average queue size for searches on the remote node
+
+      - name: adaptiveReplicaSelection.service.time.avg
+        source: avg_service_time_ns
+        type: long_gauge
+        label: average service time
+        description: exponentially weighted moving average task execution time on the remote node
+        unit: ns
+
+      - name: adaptiveReplicaSelection.response.time.avg
+        source: avg_response_time_ns
+        type: long_gauge
+        label: average response time
+        description: exponentially weighted moving average response time on the remote node
+        unit: ns
+
+      - name: adaptiveReplicaSelection.rank
+        source: rank
+        type: double_gauge
+        label: rank
+        description: rank of the remote node used for replica selection
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.remote.node.id
+        value: ${remoteNodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.remote.node
+        value: json:smile:/_cluster/state/nodes?local=true&format=smile $.nodes.${remoteNodeId}.name
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId

--- a/opensearch/json-circuit-breaker.yml
+++ b/opensearch/json-circuit-breaker.yml
@@ -1,0 +1,194 @@
+type: json
+data:
+  url: /_nodes/_local/stats/breaker?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: breaker_in_flight_requests
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.breakers.in_flight_requests
+
+    metric:
+      - name: circuitBreaker.inFlightRequests.size.max
+        source: limit_size_in_bytes
+        type: long_gauge
+        label: inFlightRequests max size
+        description: max in-flight requests size
+        unit: bytes
+
+      - name: circuitBreaker.inFlightRequests.size.estimate
+        source: estimated_size_in_bytes
+        type: long_gauge
+        label: inFlightRequests estimated size
+        description: estimated in-flight requests size
+        unit: bytes
+
+      - name: circuitBreaker.inFlightRequests.size.overhead
+        source: overhead
+        type: double_gauge
+        label: inFlightRequests overhead
+        description: in-flight requests overhead
+
+      - name: circuitBreaker.inFlightRequests.tripped
+        source: tripped
+        type: counter
+        label: inFlightRequests tripped
+        description: in-flight requests circuit breaker tripped
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: breaker_parent
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.breakers.parent
+
+    metric:
+      - name: circuitBreaker.parent.size.max
+        source: limit_size_in_bytes
+        type: long_gauge
+        label: parent max size
+        description: max parent circuit breaker size
+        unit: bytes
+
+      - name: circuitBreaker.parent.size.estimate
+        source: estimated_size_in_bytes
+        type: long_gauge
+        label: parent estimated size
+        description: estimated parent circuit breaker size
+        unit: bytes
+
+      - name: circuitBreaker.parent.size.overhead
+        source: overhead
+        type: double_gauge
+        label: parent overhead
+        description: parent circuit breaker overhead
+
+      - name: circuitBreaker.parent.tripped
+        source: tripped
+        type: counter
+        label: parent tripped
+        description: parent circuit breaker tripped
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: breaker_fielddata
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.breakers.fielddata
+
+    metric:
+      - name: circuitBreaker.fieldData.size.max
+        source: limit_size_in_bytes
+        type: long_gauge
+        label: fieldData max size
+        description: max fieldData size
+        unit: bytes
+
+      - name: circuitBreaker.fieldData.size.estimate
+        source: estimated_size_in_bytes
+        type: long_gauge
+        label: fieldData estimated size
+        description: estimated fieldData size
+        unit: bytes
+
+      - name: circuitBreaker.fieldData.size.overhead
+        source: overhead
+        type: double_gauge
+        label: fieldData overhead
+        description: fieldData overhead
+
+      - name: circuitBreaker.fieldData.tripped
+        source: tripped
+        type: counter
+        label: fieldData tripped
+        description: fieldData circuit breaker tripped
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: breaker_request
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.breakers.request
+
+    metric:
+      - name: circuitBreaker.request.size.max
+        source: limit_size_in_bytes
+        type: long_gauge
+        label: request maximum size
+        description: max request size
+        unit: bytes
+
+      - name: circuitBreaker.request.size.estimate
+        source: estimated_size_in_bytes
+        type: long_gauge
+        label: request estimated size
+        description: estimated request size
+        unit: bytes
+
+      - name: circuitBreaker.request.size.overhead
+        source: overhead
+        type: double_gauge
+        label: request overhead
+        description: request overhead
+
+      - name: circuitBreaker.request.tripped
+        source: tripped
+        type: counter
+        label: request tripped
+        description: request circuit breaker tripped
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId

--- a/opensearch/json-cluster-health.yml
+++ b/opensearch/json-cluster-health.yml
@@ -1,0 +1,73 @@
+type: json
+data:
+  url: /_cluster/health?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+
+observation:
+  - name: clusterHealth
+    metricNamespace: opensearch
+    path: $.
+
+    metric:
+      - name: cluster.nodes
+        source: number_of_nodes
+        type: long_gauge
+        label: nodes
+        description: Number of nodes in the cluster
+
+      - name: cluster.nodes.data
+        source: number_of_data_nodes
+        type: long_gauge
+        label: data nodes
+        description: Number of data nodes in the cluster
+
+      - name: cluster.health.shards.active.primary
+        source: active_primary_shards
+        type: long_gauge
+        label: active primary shards
+        description: Number of active primary shards
+
+      - name: cluster.health.shards.active
+        source: active_shards
+        type: long_gauge
+        label: active shards
+        description: Number of active shards
+
+      - name: cluster.health.shards.relocating
+        source: relocating_shards
+        type: long_gauge
+        label: relocating shards
+        description: Number of currently relocating shards
+
+      - name: cluster.health.shards.initializing
+        source: initializing_shards
+        type: long_gauge
+        label: initializing shards
+        description: Number of currently initializing shards
+
+      - name: cluster.health.shards.unassigned
+        source: unassigned_shards
+        type: long_gauge
+        label: unassigned shards
+        description: Number of currently unassigned shards
+
+      - name: cluster.health.pendingTasks.total
+        source: number_of_pending_tasks
+        type: long_gauge
+        label: pending tasks
+        description: Number of currently pending tasks in master's queue
+
+      - name: cluster.health.pendingTasks.maxQueueTime
+        source: task_max_waiting_in_queue_millis
+        type: long_gauge
+        label: pending tasks max waiting time
+        description: Maximum time for a task in master's queue
+        unit: ms
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+

--- a/opensearch/json-connections.yml
+++ b/opensearch/json-connections.yml
@@ -1,0 +1,95 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: connections_http
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.http
+
+    metric:
+      - name: connection.http.current.open
+        source: current_open
+        type: long_gauge
+        label: open HTTP conns
+        description: open HTTP conns (current_open)
+
+      - name: connection.http.total.opened
+        source: total_opened
+        type: long_gauge
+        label: total opened HTTP conns
+        description: total opened HTTP conns (total_opened)
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: connections_transport
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.transport
+
+    metric:
+      - name: connection.tcp.server.open
+        source: server_open
+        type: long_gauge
+        label: open TCP conns
+        description: open TCP conns (server_open)
+
+      - name: transport.rx.packets
+        source: rx_count
+        type: counter
+        label: network received packets
+        description: network received packets count (rx_count)
+
+      - name: transport.rx.bytes
+        source: rx_size_in_bytes
+        type: counter
+        label: network received size
+        description: network received size (rx_size)
+        unit: bytes
+
+      - name: transport.tx.packets
+        source: tx_count
+        type: counter
+        label: network transmitted packets
+        description: network transmitted packets count (tx_count)
+
+      - name: transport.tx.bytes
+        source: tx_size_in_bytes
+        type: counter
+        label: network transmitted size
+        description: network transmitted size (tx_size)
+        unit: bytes
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-discovery.yml
+++ b/opensearch/json-discovery.yml
@@ -1,0 +1,49 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: published_cluster_states
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.discovery.published_cluster_states
+
+    metric:
+      - name: cluster.state.published.full
+        source: full_states
+        type: counter
+        label: full cluster state updates
+        description: full cluster state updates published
+
+      - name: cluster.state.published.diff.incompatible
+        source: incompatible_diffs
+        type: counter
+        label: cluster state incompatible diff updates
+        description: cluster state incompatible diff updates published
+
+      - name: cluster.state.published.diff.compatible
+        source: compatible_diffs
+        type: counter
+        label: cluster state compatible diff updates
+        description: cluster state compatible diff updates published
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-index.yml
+++ b/opensearch/json-index.yml
@@ -1,0 +1,271 @@
+type: json
+data:
+  # use the same URL as other index-related collector configs which enables caching of response data and
+  # reduced overhead SPM JSON-based monitor has on the system
+  url: /_stats/indexing,store,search,merge,refresh,flush,docs,get,segments,recovery,completion,translog?level=shards&format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+  async: true
+  # custom jsonHandlerClass (provided by Sematext) is used to optimally parse this specific response json
+  jsonHandlerClass: com.sematext.spm.client.es.CustomEsShardStatsJsonHandler
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+require:
+  - className: com.sematext.spm.client.es.IsDataNodeCheck
+    values: true
+
+observation:
+  - name: indexStats_docs_total
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].docs
+
+    metric:
+      - name: index.docs.total
+        source: count
+        type: long_gauge
+        agentAggregation: SUM
+        label: docs count
+        description: docs count on all (primary and replica) shards
+
+      - name: index.docs.deleted.total
+        source: deleted
+        type: long_gauge
+        agentAggregation: SUM
+        label: docs deleted
+        description: docs deleted on all (primary and replica) shards
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: indexStats_store_total
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].store
+
+    metric:
+      - name: index.files.size.total
+        source: size_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: size on disk
+        description: size on the disk of all (primary and replica) shards
+        unit: bytes
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: indexStats_indexing_total
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].indexing
+
+    metric:
+      - name: indexing.docs.added.total
+        source: index_total
+        type: counter
+        agentAggregation: SUM
+        label: indexed docs
+        description: docs indexed on all (primary and replica) shards
+
+      - name: indexing.docs.deleted.total
+        source: delete_total
+        type: counter
+        agentAggregation: SUM
+        label: deleted docs
+        description: docs deleted on all (primary and replica) shards
+
+      - name: indexing.time.added.total
+        source: index_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: indexing time
+        description: time spent indexing on all (primary and replica) shards
+        unit: ms
+
+      - name: indexing.time.deleted.total
+        source: delete_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: deleting time
+        description: time spent deleting on all (primary and replica) shards
+        unit: ms
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: indexStats_recovery
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].recovery
+
+    metric:
+      - name: index.recovery.time.throttled
+        source: throttle_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: recovery throttle time
+        description: time during which recovery was throttled (due to indices.recovery.max_bytes_per_sec limit)
+        unit: ms
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: indexStats_completion
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].completion
+
+    metric:
+      - name: index.completion.size
+        source: size_in_bytes
+        type: long_gauge
+        label: completion memory
+        description: memory used by the Completion Suggester
+        unit: bytes
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: indexStats_translog
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].translog
+
+    metric:
+      - name: index.translog.size
+        source: size_in_bytes
+        type: long_gauge
+        agentAggregation: MAX
+        label: translog size
+        description: transaction log size
+        unit: bytes
+
+      - name: index.translog.operations
+        source: operations
+        type: long_gauge
+        agentAggregation: MAX
+        label: translog operations
+        description: number of operations in the transaction log
+
+      - name: index.translog.uncommittedSize
+        source: uncommitted_size_in_bytes
+        type: long_gauge
+        agentAggregation: MAX
+        label: translog uncommitted size
+        description: transaction log uncommitted size
+        unit: bytes
+
+      - name: index.translog.uncommittedOperations
+        source: uncommitted_operations
+        type: long_gauge
+        agentAggregation: MAX
+        label: translog uncommitted operations
+        description: number of uncommitted operations in the transaction log
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId

--- a/opensearch/json-ingest.yml
+++ b/opensearch/json-ingest.yml
@@ -1,0 +1,54 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: ingest_stats
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.ingest.pipelines.${pipeline}
+
+    metric:
+      - name: ingest.calls.total
+        source: count
+        type: counter
+        label: ingest calls
+        description: number of calls to this pipeline
+
+      - name: ingest.calls.errors
+        source: failed
+        type: counter
+        label: ingest failures
+        description: number of failed calls to this pipeline
+
+      - name: ingest.time
+        source: time_in_millis
+        type: counter
+        label: ingest time
+        description: time spent in this pipeline
+        unit: ms
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.ingest.pipeline
+        value: ${pipeline}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+        

--- a/opensearch/json-io.yml
+++ b/opensearch/json-io.yml
@@ -1,0 +1,43 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: io_stats
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.fs.io_stats.total
+
+    metric:
+      - name: disk.io.operations.read
+        source: read_operations
+        type: counter
+        label: read ops
+        description: disk IO read operations
+
+      - name: disk.io.operations.write
+        source: write_operations
+        type: counter
+        label: write ops
+        description: disk IO write operations
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-jvm-gc.yml
+++ b/opensearch/json-jvm-gc.yml
@@ -1,0 +1,47 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: jvmGcStats_collectors
+    metricNamespace: jvm
+    path: $.nodes.${nodeId}.jvm.gc.collectors.${gcName}
+
+    metric:
+      - name: gc.collection.count
+        source: collection_count
+        type: counter
+        label: gc collection count
+        description: count of GC collections
+
+      - name: gc.collection.time
+        source: collection_time_in_millis
+        type: counter
+        label: gc collection time
+        description: duration of GC collections
+        unit: ms
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: jvm.gc
+        value: ${gcName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-jvm-memory.yml
+++ b/opensearch/json-jvm-memory.yml
@@ -1,0 +1,59 @@
+type: json
+data:
+  url: /_nodes/_local/stats/jvm?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: jvmMemoryStats_memory
+    metricNamespace: jvm
+    path: $.nodes.${nodeId}.jvm.mem
+
+    metric:
+      - name: heap.used
+        source: heap_used_in_bytes
+        type: gauge
+        label: heap_used
+        description: jvm heap used memory
+        unit: bytes
+
+      - name: heap.committed
+        source: heap_committed_in_bytes
+        type: gauge
+        label: heap.committed
+        description: jvm heap committed
+        unit: bytes
+
+      - name: nonheap.used
+        source: non_heap_used_in_bytes
+        type: gauge
+        label: non_heap_used
+        description: jvm non-heap used memory
+        unit: bytes
+
+      - name: nonheap.committed
+        source: non_heap_committed_in_bytes
+        type: gauge
+        label: non_heap_committed
+        description: jvm non-heap committed
+        unit: bytes
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-jvm-os.yml
+++ b/opensearch/json-jvm-os.yml
@@ -1,0 +1,43 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: jvmOsStats
+    metricNamespace: jvm
+    path: $.nodes.${nodeId}.process
+
+    metric:
+      - name: files.open
+        source: open_file_descriptors
+        type: gauge
+        label: open files
+        description: jvm currently open files
+
+      - name: files.max
+        source: max_file_descriptors
+        type: gauge
+        label: max open files
+        description: jvm max open files limit
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-jvm-pool.yml
+++ b/opensearch/json-jvm-pool.yml
@@ -1,0 +1,48 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: jvmPoolStats_pools
+    metricNamespace: jvm
+    path: $.nodes.${nodeId}.jvm.mem.pools.${poolName}
+
+    metric:
+      - name: pool.used
+        source: used_in_bytes
+        type: gauge
+        label: used
+        description: jvm pool used memory
+        unit: bytes
+
+      - name: pool.max
+        source: max_in_bytes
+        type: gauge
+        label: used
+        description: jvm pool max memory
+        unit: bytes
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: jvm.memory.pool
+        value: ${poolName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-jvm-threadpool.yml
+++ b/opensearch/json-jvm-threadpool.yml
@@ -1,0 +1,43 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: jvmThreadPoolStats
+    metricNamespace: jvm
+    path: $.nodes.${nodeId}.jvm.threads
+
+    metric:
+      - name: threads
+        source: count
+        type: gauge
+        label: thread count
+        description: current jvm thread count
+
+      - name: threads.peak
+        source: peak_count
+        type: gauge
+        label: peak thread count
+        description: peak jvm thread count
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-merge.yml
+++ b/opensearch/json-merge.yml
@@ -1,0 +1,111 @@
+type: json
+data:
+  # use the same URL as other index-related collector configs which enables caching of response data and
+  # reduced overhead SPM JSON-based monitor has on the system
+  # URL itself is used to provide data on which bean paths are then applied
+  url: /_stats/indexing,store,search,merge,refresh,flush,docs,get,segments,recovery,completion,translog?level=shards&format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+  async: true
+  # custom jsonHandlerClass (provided by Sematext) is used to optimally parse this specific response json
+  jsonHandlerClass: com.sematext.spm.client.es.CustomEsShardStatsJsonHandler
+
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+# this makes the config applicable only on data nodes - we don't want to load master and client nodes with
+# stats queries which will never return any metric that could be recorded
+require:
+  - className: com.sematext.spm.client.es.IsDataNodeCheck
+    values: true
+
+observation:
+  - name: mergeStats_total
+    metricNamespace: opensearch
+
+    # Attribute 'path' specifies set of objects which should be monitored. For each placeholder (defined with ${...}) any
+    # value will be accepted (while also storing the value of that placeholder). In the example below, if some setup has
+    # 3 indices (say 'A', 'B' and 'C), each with 2 shards, meaning a total of 6 shards, there will be a total of 6
+    # matching objects found by this path expression (regardless off on which nodes which shards are, since total number of
+    # shards is 6 anyway).
+    # For each of those 6 objects, placeholder values will be available for use in tag definitions (notice how value of
+    # "es.node.id" and "es.index" tags are specified - they will be resolved to exact values matching one of those 6 objects).
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].merges
+
+    metric:
+      - name: indexing.merges.total
+        source: total
+        type: counter
+        agentAggregation: SUM
+        label: merge count
+        description: merge count on all (primary and replica) shards
+
+      - name: indexing.merges.time.total
+        source: total_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: merge time
+        description: merge time on all (primary and replica) shards
+        unit: ms
+
+      - name: indexing.merges.docs.total
+        source: total_docs
+        type: counter
+        agentAggregation: SUM
+        label: merged docs count
+        description: merged docs count on all (primary and replica) shards
+
+      - name: indexing.merges.docs.size.total
+        source: total_size_in_bytes
+        type: counter
+        agentAggregation: SUM
+        label: merged docs size
+        description: merged docs size on all (primary and replica) shards
+        unit: bytes
+
+      - name: indexing.merges.throttled.time.total
+        source: total_throttled_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: throttled merge time
+        description: throttled time for merges (i.e. when merges fall behind) on all (primary and replica) shards
+        unit: ms
+
+      - name: indexing.merges.throttled.size.total
+        source: total_auto_throttle_in_bytes
+        type: counter
+        agentAggregation: SUM
+        label: throttled merge size
+        description: size of throttled merges on all (primary and replica) shards
+        unit: bytes
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    # filtering-out all non-local nodes. We allow only "nodeId" value that matches the result of specified json expression.
+    # The expression itself finds the only matching object and uses value from placeholder ${localNodeId} as result. If
+    # there were multiple matching objects in json received from this URL, json expression would fail (since result
+    # couldn't be uniquely extracted).
+    # Tag "es.node" uses similar expression, the only difference is ".name" part at the end. That expression will return
+    # result that is equal to "name" property of only resulting object (again, in case of multiple matches, it would fail)
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-node-cache.yml
+++ b/opensearch/json-node-cache.yml
@@ -1,0 +1,213 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: cacheStats_nodeCache_field
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.indices.fielddata
+
+    metric:
+      - name: cache.field.evicted
+        source: evictions
+        type: counter
+        label: field cache evictions
+        description: Field cache evictions
+
+      - name: cache.field.size
+        source: memory_size_in_bytes
+        type: long_gauge
+        label: field cache size
+        description: Field cache size
+        unit: bytes
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: cacheStats_nodeCache_filter
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.indices.filter_cache
+
+    metric:
+      - name: cache.filter.evicted
+        source: evictions
+        type: counter
+        label: filter cache evictions
+        description: Filter cache evictions
+
+      - name: cache.filter.size
+        source: memory_size_in_bytes
+        type: long_gauge
+        label: filter cache size
+        description: Filter cache size
+        unit: bytes
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: cacheStats_nodeCache_query
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.indices.query_cache
+
+    metric:
+      - name: cache.filter.evicted
+        source: evictions
+        type: counter
+        label: filter cache evictions
+        description: Filter cache evictions
+
+      - name: cache.filter.size
+        source: memory_size_in_bytes
+        type: long_gauge
+        label: filter cache size
+        description: Filter cache size
+        unit: bytes
+
+      - name: cache.filter.size.count
+        source: cache_count
+        type: counter
+        label: filter/query cache count
+        description: Filter/query cache count of elements
+
+      - name: cache.filter.hits
+        source: hit_count
+        type: counter
+        label: filter/query cache hit count
+        description: Number of requests hitting the filter/query cache
+
+      - name: cache.filter.misses
+        source: miss_count
+        type: counter
+        label: filter/query cache miss count
+        description: Number of requests missing the filter/query cache
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: cacheStats_nodeCache_request
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.indices.request_cache
+
+    metric:
+      - name: cache.request.evicted
+        source: evictions
+        type: counter
+        label: request cache evictions
+        description: Request cache evictions
+
+      - name: cache.request.size
+        source: memory_size_in_bytes
+        type: long_gauge
+        label: request cache size
+        description: Request cache size
+        unit: bytes
+
+      - name: cache.request.hits
+        source: hit_count
+        type: counter
+        label: request cache hit count
+        description: Number of requests hitting the request cache
+
+      - name: cache.request.misses
+        source: miss_count
+        type: counter
+        label: request cache miss count
+        description: Number of requests missing the request cache
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+
+  - name: cacheStats_nodeCache_warmer
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.indices.warmer
+
+    metric:
+      - name: cache.warmer.current
+        source: current
+        type: long_gauge
+        label: warmer current
+        description: Warmer current
+
+      - name: cache.warmer.total
+        source: total
+        type: counter
+        label: warmer total
+        description: Warmer total
+        unit: bytes
+
+      - name: cache.warmer.time
+        source: total_time_in_millis
+        type: counter
+        label: warmer total time
+        description: Warmer total time
+        unit: ms
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-node-info.yml
+++ b/opensearch/json-node-info.yml
@@ -1,0 +1,37 @@
+type: json
+data:
+  url: /_nodes/_local/os?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: node_os_stats
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.os
+
+    metric:
+      - name: cpu.allocated.count
+        source: allocated_processors
+        type: long_gauge
+        label: number of processors
+        description: number of processors allocated to the OpenSearch process
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-refresh-flush.yml
+++ b/opensearch/json-refresh-flush.yml
@@ -1,0 +1,100 @@
+type: json
+data:
+  # use the same URL as other index-related collector configs which enables caching of response data and
+  # reduced overhead SPM JSON-based monitor has on the system
+  url: /_stats/indexing,store,search,merge,refresh,flush,docs,get,segments,recovery,completion,translog?level=shards&format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+  async: true
+  # custom jsonHandlerClass (provided by Sematext) is used to optimally parse this specific response json
+  jsonHandlerClass: com.sematext.spm.client.es.CustomEsShardStatsJsonHandler
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+require:
+  - className: com.sematext.spm.client.es.IsDataNodeCheck
+    values: true
+
+observation:
+  - name: refreshFlushStats_refresh_total
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].refresh
+
+    metric:
+      - name: indexing.refreshes.total
+        source: total
+        type: counter
+        agentAggregation: SUM
+        label: refresh count
+        description: refresh count on all (primary and replica) shards
+
+      - name: indexing.refreshes.time.total
+        source: total_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: refresh time
+        description: refresh time on all (primary and replica) shards
+        unit: ms
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+  - name: refreshFlushStats_flush_total
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].flush
+
+    metric:
+      - name: indexing.flushes.total
+        source: total
+        type: counter
+        agentAggregation: SUM
+        label: flush count
+        description: flush count on all (primary and replica) shards
+
+      - name: indexing.flushes.time.total
+        source: total_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: flush time
+        description: flush time on all (primary and replica) shards
+        unit: ms
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-script.yml
+++ b/opensearch/json-script.yml
@@ -1,0 +1,49 @@
+type: json
+data:
+  url: /_nodes/_local/stats/indices,transport,http,thread_pool,jvm,process,fs,script,discovery,ingest,adaptive_selection?format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: script_stats
+    metricNamespace: opensearch
+    path: $.nodes.${nodeId}.script
+
+    metric:
+      - name: script.compilations.total
+        source: compilations
+        type: counter
+        label: script compilations
+        description: script compilations (use params in scripts to reduce them)
+
+      - name: script.cache.evictions
+        source: cache_evictions
+        type: counter
+        label: script cache evictions
+        description: script cache evictions
+
+      - name: script.compilations.limitTriggered
+        source: compilation_limit_triggered
+        type: counter
+        label: script compilations limit triggered
+        description: script compilations circuit breaker triggered (see script.max_compilations_rate setting)
+
+    tag:
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-search.yml
+++ b/opensearch/json-search.yml
@@ -1,0 +1,193 @@
+type: json
+data:
+  # use the same URL as other index-related collector configs which enables caching of response data and
+  # reduced overhead SPM JSON-based monitor has on the system
+  url: /_stats/indexing,store,search,merge,refresh,flush,docs,get,segments,recovery,completion,translog?level=shards&format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+  # async="true" - because this particular call can be very slow in some setups, no point in blocking everything with it
+  async: true
+  # custom jsonHandlerClass (provided by Sematext) is used to optimally parse this specific response json
+  jsonHandlerClass: com.sematext.spm.client.es.CustomEsShardStatsJsonHandler
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+require:
+  - className: com.sematext.spm.client.es.IsDataNodeCheck
+    values: true
+
+observation:
+  - name: searchStats_search_total
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].search
+
+    metric:
+      - name: query.count.total
+        source: query_total
+        type: counter
+        agentAggregation: SUM
+        label: query count
+        description: query count on all (primary and replica) shards
+
+      - name: query.latency.time.total
+        source: query_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: query latency
+        description: query latency on all (primary and replica) shards
+        unit: ms
+
+      - name: fetch.count.total
+        source: fetch_total
+        type: counter
+        agentAggregation: SUM
+        label: fetch count
+        description: fetch count on all (primary and replica) shards
+
+      - name: fetch.latency.time.total
+        source: fetch_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: fetch latency
+        description: fetch latency on all (primary and replica) shards
+        unit: ms
+
+      - name: suggest.count.total
+        source: suggest_total
+        type: counter
+        agentAggregation: SUM
+        label: suggest count
+        description: suggest count on all (primary and replica) shards
+
+      - name: suggest.latency.time.total
+        source: suggest_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: suggest latency
+        description: suggest latency on all (primary and replica) shards
+        unit: ms
+
+      - name: scroll.count.total
+        source: scroll_total
+        type: counter
+        agentAggregation: SUM
+        label: scroll count
+        description: scroll count on all (primary and replica) shards
+
+      - name: scroll.latency.time.total
+        source: scroll_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: scroll latency
+        description: scroll latency on all (primary and replica) shards
+        unit: ms
+
+      - name: search.opencontexts.total
+        source: open_contexts
+        type: long_gauge
+        agentAggregation: SUM
+        label: search open contexts
+        description: open search contexts on all (primary and replica) shards
+
+      - name: query.latency.total.avg
+        source: func:DoubleDivide(query.latency.time.total,query.count.total)
+        type: gauge
+        agentAggregation: AVG
+        pctls: 99,95,50
+        label: avg. query latency
+        description: avg. query latency on all (primary and replica) shards
+        unit: ms
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+  - name: searchStats_get_total
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].get
+
+    metric:
+      - name: request.rtg.total
+        source: total
+        type: counter
+        agentAggregation: SUM
+        label: real-time get count
+        description: real-time get count on all (primary and replica) shards
+
+      - name: request.rtg.time.total
+        source: time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: real-time get latency
+        description: real-time latency on all (primary and replica) shards
+        unit: ms
+
+      - name: request.rtg.exists.total
+        source: exists_total
+        type: counter
+        agentAggregation: SUM
+        label: real-time get exists count
+        description: real-time get exists count on all (primary and replica) shards
+
+      - name: request.rtg.exists.time.total
+        source: exists_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: real-time get exists latency
+        description: real-time get exists latency on all (primary and replica) shards
+        unit: ms
+
+      - name: request.rtg.missing.total
+        source: missing_total
+        type: counter
+        agentAggregation: SUM
+        label: real-time get missing count
+        description: real-time get missing count on all (primary and replica) shards
+
+      - name: request.rtg.missing.time.total
+        source: missing_time_in_millis
+        type: counter
+        agentAggregation: SUM
+        label: real-time get missing latency
+        description: real-time get missing latency on all (primary and replica) shards
+        unit: ms
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+
+

--- a/opensearch/json-segments.yml
+++ b/opensearch/json-segments.yml
@@ -1,0 +1,133 @@
+type: json
+data:
+  # use the same URL as other index-related collector configs which enables caching of response data and
+  # reduced overhead SPM JSON-based monitor has on the system
+  url: /_stats/indexing,store,search,merge,refresh,flush,docs,get,segments,recovery,completion,translog?level=shards&format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+  # async="true" - because this particular call can be very slow in some setups, no point in blocking everything with it
+  async: true
+  # custom jsonHandlerClass (provided by Sematext) is used to optimally parse this specific response json
+  jsonHandlerClass: com.sematext.spm.client.es.CustomEsShardStatsJsonHandler
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+require:
+  - className: com.sematext.spm.client.es.IsDataNodeCheck
+    values: true
+
+observation:
+  - name: segmentStats_segments_total
+    metricNamespace: opensearch
+    path: $.indices.${indexName}.shards.${shard}[?(@.routing.node=${nodeId})].segments
+
+    metric:
+      - name: segments.count.total
+        source: count
+        type: long_gauge
+        agentAggregation: SUM
+        label: segments count
+        description: number of segments
+
+      - name: segments.memory.total
+        source: memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: segments memory
+        description: total memory for segment-related data structures
+        unit: bytes
+
+      - name: segments.memory.terms
+        source: terms_memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: terms memory
+        description: memory used by the terms dictionary
+        unit: bytes
+
+      - name: segments.memory.storedFields
+        source: stored_fields_memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: stored fields memory
+        description: memory used by stored fields
+        unit: bytes
+
+      - name: segments.memory.termVectors
+        source: term_vectors_memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: term vectors memory
+        description: memory used by term vectors
+        unit: bytes
+
+      - name: segments.memory.norms
+        source: norms_memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: norms memory
+        description: memory used by (length) norms
+        unit: bytes
+
+      - name: segments.memory.points
+        source: points_memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: points memory
+        description: memory used by point fields (includes numeric, date, geo)
+        unit: bytes
+
+      - name: segments.memory.docValues
+        source: doc_values_memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: doc values memory
+        description: memory used by doc values
+        unit: bytes
+
+      - name: segments.memory.indexWriter
+        source: index_writer_memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: indexing buffer memory
+        description: memory used by the IndexWriter
+        unit: bytes
+
+      - name: segments.memory.versionMap
+        source: version_map_memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: version map memory
+        description: memory used by the version map
+        unit: bytes
+
+      - name: segments.memory.fixedBitSet
+        source: fixed_bit_set_memory_in_bytes
+        type: long_gauge
+        agentAggregation: SUM
+        label: fixed bitset memory
+        description: memory used by the fixed bitset that speeds up nested queries/aggregations
+        unit: bytes
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-shards-unassigned.yml
+++ b/opensearch/json-shards-unassigned.yml
@@ -1,0 +1,35 @@
+type: json
+data:
+  url: /_cluster/health?level=indices&format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+  async: false
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+require:
+  - className: com.sematext.spm.client.es.IsDataNodeCheck
+    values: true
+
+observation:
+  # unassigned shards are related to particular index (and cluster), they have no relation to any node
+  - name: shardStats_unassigned
+    metricNamespace: opensearch
+    path: $.indices.${indexName}
+
+    metric:
+      - name: cluster.shards.unassigned
+        source: unassigned_shards
+        type: long_gauge
+        label: unassigned shards
+        description: Number of unassigned shards
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.index
+        value: ${indexName}
+

--- a/opensearch/json-shards.yml
+++ b/opensearch/json-shards.yml
@@ -1,0 +1,70 @@
+type: json
+data:
+  url: /_cluster/state/nodes,routing_table,routing_nodes,master_node?local=true&format=smile
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+  async: false
+  # custom jsonHandlerClass (provided by Sematext) is used to optimally parse this specific response json
+  jsonHandlerClass: com.sematext.spm.client.es.CustomEsClusterStateJsonHandler
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+require:
+  - className: com.sematext.spm.client.es.IsDataNodeCheck
+    values: true
+
+observation:
+  - name: shardStats
+    metricNamespace: opensearch
+    # path declared below will have N matches for each node-index combination... however, collectors are created
+    # "1 for each distinct path", so there will be no duplicate collectors and we will really get just one measurement
+    # for each node-index combination
+    path: $.routing_nodes.nodes.${nodeId}[?(@.index=${indexName})]
+
+    metric:
+      - name: cluster.shards.active
+        source: json:smile:/_cluster/state/nodes,routing_table,routing_nodes,master_node?local=true&format=smile $.routing_nodes.nodes.${nodeId}[?(@.index=${indexName} && @.state=STARTED||RELOCATING)] return:countMatches
+        type: long_gauge
+        label: active shards
+        description: Number of active shards
+
+      - name: cluster.shards.active.primary
+        source: json:smile:/_cluster/state/nodes,routing_table,routing_nodes,master_node?local=true&format=smile $.routing_nodes.nodes.${nodeId}[?(@.index=${indexName} && @.primary=true && @.state=STARTED||RELOCATING)] return:countMatches
+        type: long_gauge
+        label: active primary shards
+        description: Number of active primary shards
+
+      - name: cluster.shards.initializing
+        source: json:smile:/_cluster/state/nodes,routing_table,routing_nodes,master_node?local=true&format=smile $.routing_nodes.nodes.${nodeId}[?(@.index=${indexName} && @.state=INITIALIZING)] return:countMatches
+        type: long_gauge
+        label: initializing shards
+        description: Number of initializing shards
+
+      - name: cluster.shards.relocating
+        source: json:smile:/_cluster/state/nodes,routing_table,routing_nodes,master_node?local=true&format=smile $.routing_nodes.nodes.${nodeId}[?(@.index=${indexName} && @.state=RELOCATING)] return:countMatches
+        type: long_gauge
+        label: relocating shards
+        description: Number of relocating shards
+
+    tag:
+      - name: opensearch.cluster
+        value: json:smile:/_cluster/health?format=smile $.cluster_name
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.index
+        value: ${indexName}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+

--- a/opensearch/json-threadpool.yml
+++ b/opensearch/json-threadpool.yml
@@ -1,0 +1,88 @@
+type: json
+data:
+  url: /_cat/thread_pool?format=smile&h=node_id,host,ip,post,name,type,active,size,queue,queue_size,rejected,largest,completed,min,max,keep_alive
+  server: ${ST_MONITOR_OPENSEARCH_NODE_HOSTPORT}
+  basicHttpAuthUsername: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_USERNAME}
+  basicHttpAuthPassword: ${ST_MONITOR_OPENSEARCH_NODE_BASICAUTH_PASSWORD}
+  smileFormat: true
+require:
+  - className: com.sematext.spm.client.es.EsVersionCheck
+    values: 1-*
+
+observation:
+  - name: threadPoolStats
+    metricNamespace: opensearch
+    path: $.[?(@.name=${threadPool} && @.node_id=${nodeId})]
+
+    metric:
+      - name: thread.pool.active
+        source: active
+        type: long_gauge
+        label: active threads
+        description: active threads
+
+      - name: thread.pool.size
+        source: size
+        type: long_gauge
+        label: thread pool size
+        description: thread pool size
+
+      - name: thread.pool.queue
+        source: queue
+        type: long_gauge
+        label: thread pool queue
+        description: thread pool queue
+
+      - name: thread.pool.queue.size
+        source: queue_size
+        type: long_gauge
+        label: thread pool queue size
+        description: thread pool queue size
+
+      - name: thread.pool.rejected
+        source: rejected
+        type: counter
+        label: rejected threads
+        description: rejected threads
+
+      - name: thread.pool.largest
+        source: largest
+        type: long_gauge
+        label: thread pool largest
+        description: thread pool largest
+
+      - name: thread.pool.completed
+        source: completed
+        type: counter
+        label: completed threads
+        description: complete threads
+
+      - name: thread.pool.min
+        source: min
+        type: long_gauge
+        label: thread pool min
+        description: thread pool min
+
+      - name: thread.pool.max
+        source: max
+        type: long_gauge
+        label: thread pool max
+        description: thread pool max
+
+    tag:
+      - name: opensearch.node
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.name
+
+      - name: opensearch.node.role
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId}.roles return:ConcatCollection()
+
+      - name: opensearch.node.id
+        value: ${nodeId}
+
+      - name: opensearch.thread.pool
+        value: ${threadPool}
+
+    accept:
+      - name: nodeId
+        value: json:smile:/_nodes/_local?format=smile $.nodes.${localNodeId} return:pathTags:localNodeId
+


### PR DESCRIPTION
It's similar to the Elasticsearch integration, though some metrics are a bit different. I've changed the namespace and tag names, but we reuse the same version checks.

I've tested the integration with OpenSearch 2.0.1, but I'm expecting 1.x to work as well, hence the 1.x constraint to versions. A lot of YAML files and chunks of files that you can still find in the Elasticsearch integration were removed as well, in an effort to clean up and only support recent versions (OpenSearch is by definition recent).